### PR TITLE
修复access-inline插件遇到access$方法中只有LDC指令时的NPE问题

### DIFF
--- a/access-inline-plugin/src/main/java/com/ss/android/ugc/bytex/access_inline/visitor/PreProcessClassVisitor.java
+++ b/access-inline-plugin/src/main/java/com/ss/android/ugc/bytex/access_inline/visitor/PreProcessClassVisitor.java
@@ -246,6 +246,14 @@ public class PreProcessClassVisitor extends BaseClassVisitor {
                     if (insnNode.getOpcode() > Opcodes.MONITOREXIT) {
                         throw new ShouldSkipInlineException("Unexpected new instruction in access$ method body.");
                     }
+                    /*
+                     * 遇到LDC指令跳过
+                     * 暂时无法给access$MethodEntity 设置target
+                     * 导致使用target时候NPE问题
+                     */
+                    if (insnNode.getOpcode() == Opcodes.LDC) {
+                        throw new ShouldSkipInlineException("Unexpected LDC instruction in access$ method body.");
+                    }
                     if (shouldSkipVarInsn && insnNode.getOpcode() >= Opcodes.ILOAD && insnNode.getOpcode() <= Opcodes.SALOAD) {
                         varLoadInsnCount++;
                         continue;


### PR DESCRIPTION
**复现步骤**
1. 先写一个类，如下:
```
class TestClass {
  fun func1(): Int {
    return ARG_1 + ARG_2
  }
}

private val ARG_1 = 1
private val ARG_2 = 0
```
2. 将Bytex的access-inline与const-inline插件集成，顺序为先执行const，再执行access
```
    apply plugin: 'bytex.const_inline'
    const_inline {
        enable true
        enableInDebug true
        logLevel "INFO"
        autoFilterReflectionField = true  //使用插件内置的反射检查过滤掉可能的反射常量，建议为true
        //supposesReflectionWithString = false //使用插件内置字符串匹配可能反射常量，建议为false
        skipWithRuntimeAnnotation true //过滤掉带有运行时注解的常量，推荐true
        skipWithAnnotations = [
                //过滤掉被注解注释过的常量，包含class
                "android/support/annotation/Keep",
        ]
        whiteList = [
                //跳过优化的名单
                "com/meizu/cloud/*",
        ]
    }

    apply plugin: 'bytex.access_inline'
    access_inline {
        enable true
        enableInDebug true
        logLevel "DEBUG"
    }

```
3. 编译一遍就能看到有如下错误栈：
```
Caused by: java.lang.NullPointerException
        at com.ss.android.ugc.bytex.access_inline.Context.prepare(Context.java:96)
        at com.ss.android.ugc.bytex.access_inline.AccessInlinePlugin.beforeTransform(AccessInlinePlugin.java:40)
        at com.ss.android.ugc.bytex.common.flow.main.MainTransformFlow.lambda$beforeTransform$5(MainTransformFlow.java:144)
        at com.ss.android.ugc.bytex.transformer.concurrent.Worker.lambda$null$0(Worker.java:59)

```

**原因分析**
1. access-inline插件崩溃在`Context.prepare()`方法，由于target为null导致
2. target在`PreProcessClassVisitor.refine()`方法执行时设置，但在处理`access$`方法中只包含`LDC`指令时，会出现没有设置target的情况。（经过const-inline插件优化过后，ARG_2 参数access$方法中的GET STATIC -> LDC）
3. 如果将ARG_2的值从0改为非0（例如2），变成了运行期常量，上述问题不会有，因为const-inline插件不对其处理。kotlin里`private val`本不应该被const-inline识别并处理，目前看来由于赋值的是默认值0，ARG_2成了编译期常量


**处理**
跳过包含LDC指令的`access$`方法内联